### PR TITLE
Add a log_level argument to Pusher

### DIFF
--- a/pusherclient/__init__.py
+++ b/pusherclient/__init__.py
@@ -3,7 +3,7 @@ from connection import Connection
 import hashlib
 import thread
 import hmac
-
+import logging
 
 try:
     import simplejson as json
@@ -19,14 +19,14 @@ class Pusher(object):
     client_id = 'PythonPusherClient'
     protocol = 6
 
-    def __init__(self, key, secure=True, secret=None, user_data=None):
+    def __init__(self, key, secure=True, secret=None, user_data=None, log_level=logging.INFO):
         self.key = key
         self.secret = secret
         self.user_data = user_data or {}
 
         self.channels = {}
 
-        self.connection = Connection(self._connection_handler, self._build_url(key, secure))
+        self.connection = Connection(self._connection_handler, self._build_url(key, secure), log_level=log_level)
 
     def connect(self):
         """Connect to Pusher"""


### PR DESCRIPTION
This change adds a log_level argument to the Pusher class so that the Connection object can have it's log_level set at creation time. Without this it is not possible to easily suppress the log messages generated by the Connection object.
