### PR TITLE
PythonPusherClient now uses its own logger instead of the root logger.

### DIFF
--- a/pusherclient/connection.py
+++ b/pusherclient/connection.py
@@ -34,7 +34,7 @@ class Connection(Thread):
 
         self.state = "initialized"
 
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger(self.__module__)  # create a new logger
         self.logger.addHandler(logging.StreamHandler())
         if log_level == logging.DEBUG:
             websocket.enableTrace(True)


### PR DESCRIPTION
Currently, PythonPusherClient uses the root logger, and consequently the log_level parameter changes the settings of the root logger. However, it is to be expected that applications that use PythonPusherClient, use the root logger for their own purposes. Thus, PythonPusherClient needs to have its own dedicated logger to avoid conflicts and to allow for the applications that use PythonPusherClient to be able to disable log messages from PythonPusherClient without disabling it in other parts of their application.

This simple change creates a new logger, whose name is the module name. 
