### PR TITLE
Couple fixes for better python3 support and accurate thread handling

### DIFF
--- a/pusherclient/__init__.py
+++ b/pusherclient/__init__.py
@@ -4,10 +4,6 @@ import hashlib
 import hmac
 import logging
 
-try:
-    import thread
-except:
-    import _thread as thread
 
 try:
     import simplejson as json
@@ -34,7 +30,7 @@ class Pusher(object):
 
     def connect(self):
         """Connect to Pusher"""
-        thread.start_new_thread(self.connection.run, ())
+        self.connection.start()
 
     def disconnect(self):
         """Disconnect from Pusher"""

--- a/pusherclient/connection.py
+++ b/pusherclient/connection.py
@@ -166,6 +166,9 @@ class Connection(Thread):
         if self.connection_timer:
             self.connection_timer.cancel()
 
+        if self.pong_timer:
+            self.pong_timer.cancel()
+
     def _start_timers(self):
         self._stop_timers()
 

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,7 @@ import sys
 
 VERSION = "0.2.0"
 
-if sys.version_info >= (3,):
-    requirements = ["websocket-client-py3"]
-else:
-    requirements = ["websocket-client"]
+requirements = ["websocket-client"]
 
 setup(
     name="pusherclient",


### PR DESCRIPTION
Hi there!

Module websocket-client-py3 looks outdated now (buggy socket closing) and websocket-client now support python3 so looks like its a good time to switch to a proper module.

Module _thread usage looks totally pointless - class Connection implements Thread so we can just do connection.start() and do not run thread inside thread for no reason.

Also pong_timer supposed to be cancelled in _stop_timers() as other connection-related timers.
