### PR TITLE
Don't add a handler

### DIFF
--- a/pusherclient/connection.py
+++ b/pusherclient/connection.py
@@ -35,7 +35,6 @@ class Connection(Thread):
         self.state = "initialized"
 
         self.logger = logging.getLogger(self.__module__)  # create a new logger
-        self.logger.addHandler(logging.StreamHandler())
         if log_level == logging.DEBUG:
             websocket.enableTrace(True)
         self.logger.setLevel(log_level)


### PR DESCRIPTION
Modules/libraries generally shouldn't add their own handler, since log output is usually an application level decision.
