### PR TITLE
Re-add `data` attribute deserialization

### DIFF
--- a/pusherclient/connection.py
+++ b/pusherclient/connection.py
@@ -221,7 +221,8 @@ class Connection(Thread):
             self.reconnect()
 
     def _connect_handler(self, data):
-        self.socket_id = data['socket_id']
+        parsed = json.loads(data)
+        self.socket_id = parsed['socket_id']
         self.state = "connected"
 
     def _failed_handler(self, data):


### PR DESCRIPTION
commit https://github.com/ekulyk/PythonPusherClient/commit/8b5863227b56421d338ac1c1cbf46564fe60dbe5 removes a `json.loads()` call on the "data" attribute of hash Pusher sends when a connection is established. According to [Pusher's docs](https://pusher.com/docs/pusher_protocol#double-encoding), the data attribute is JSON serialized as a _string_, which needs to be deserialized. Removing this step causes the initial connection to Pusher to fail, as the connect handler can't get the socket ID from the string:

```
Traceback (most recent call last):
  File "/src/pusherclient/pusherclient/connection.py", line 142, in _on_message
    callback(params['data'])
  File "/src/pusherclient/pusherclient/connection.py", line 225, in _connect_handler
    self.socket_id = data['socket_id']
TypeError: string indices must be integers
```

This PR re-adds the deserialization step.
