### PR TITLE
Fix some problems calling disconnect before exiting application.

### DIFF
--- a/pusherclient/connection.py
+++ b/pusherclient/connection.py
@@ -19,6 +19,7 @@ class Connection(Thread):
 
         self.event_callbacks = {}
 
+        self.disconnect_called = False
         self.needs_reconnect = False
         self.reconnect_interval = 10
 
@@ -73,6 +74,7 @@ class Connection(Thread):
 
     def disconnect(self):
         self.needs_reconnect = False
+        self.disconnect_called = True
         if self.socket:
             self.socket.close()
         self.join()
@@ -101,7 +103,7 @@ class Connection(Thread):
 
         self.socket.run_forever()
 
-        while self.needs_reconnect:
+        while self.needs_reconnect and not self.disconnect_called:
             self.logger.info("Attempting to connect again in %s seconds."
                              % self.reconnect_interval)
             self.state = "unavailable"

--- a/pusherclient/connection.py
+++ b/pusherclient/connection.py
@@ -75,6 +75,7 @@ class Connection(Thread):
         self.needs_reconnect = False
         if self.socket:
             self.socket.close()
+        self.join()
 
     def reconnect(self, reconnect_interval=10):
         self.logger.info("Connection: Reconnect in %s" % reconnect_interval)


### PR DESCRIPTION
First change prevents "Exception in thread Thread-17 (most likely raised during interpreter shutdown)" type errors by ensuring the connection thread has exited before returning from disconnect.

Second change prevent a race between _on_error and disconnect assigning to the need_reconnect flag (which, when combined with the above change, can cause disconnect to hang).
