### PR TITLE
added cluster option

### DIFF
--- a/pusherclient/__init__.py
+++ b/pusherclient/__init__.py
@@ -16,17 +16,18 @@ VERSION = "0.2.0"
 
 class Pusher(object):
     host = "ws.pusherapp.com"
+    cluster_host = "ws-%s.pusher.com"
     client_id = 'PythonPusherClient'
     protocol = 6
 
-    def __init__(self, key, secure=True, secret=None, user_data=None, log_level=logging.INFO, daemon=True, port=None, reconnect_interval=10):
+    def __init__(self, key, secure=True, secret=None, user_data=None, log_level=logging.INFO, daemon=True, port=None, reconnect_interval=10, cluster=None):
         self.key = key
         self.secret = secret
         self.user_data = user_data or {}
 
         self.channels = {}
 
-        self.url = self._build_url(key, secure, port)
+        self.url = self._build_url(key, secure, port, cluster)
 
         self.connection = Connection(self._connection_handler, self.url, log_level=log_level, daemon=daemon, reconnect_interval=reconnect_interval)
 
@@ -123,7 +124,7 @@ class Pusher(object):
         return auth_key
 
     @classmethod
-    def _build_url(cls, key, secure, port=None):
+    def _build_url(cls, key, secure, port=None, cluster=None):
         path = "/app/%s?client=%s&version=%s&protocol=%s" % (
             key,
             cls.client_id,
@@ -142,9 +143,14 @@ class Pusher(object):
             else:
                 port = 80
 
+        if cluster:
+            host = cls.cluster_host % cluster
+        else:
+            host = cls.host
+
         return "%s://%s:%s%s" % (
             proto,
-            cls.host,
+            host,
             port,
             path
         )


### PR DESCRIPTION
Recently(?) pusher introduced [clusters](https://pusher.com/docs/clusters) for new apps (old apps, those made prior to this change, still work on old location, e.g. pusherapp.com), and  this breaks most clients.

This PR aims to fix this. I haven't done extensive testing, other than letting it run for a while, only receiving data (no sending, but I guess it should work).
